### PR TITLE
add button to close video modal on mobile

### DIFF
--- a/site/assets/css/base.css
+++ b/site/assets/css/base.css
@@ -52,6 +52,17 @@
   }
 }
 
+@media screen and (min-width: 0px) and (max-width: 768px) {
+  #close-modal-button { display: block; }  /* show it on small screens */
+}
+
+@media screen and (min-width: 768px){
+  #close-modal-button { display: none; }   /* hide it elsewhere */
+}
+
+.btn-close {
+  background-color: #eee;
+}
 
 /* Styles for bottom strip of page */
 .bottom-gray-bar {

--- a/site/index.html
+++ b/site/index.html
@@ -40,8 +40,13 @@
           <div class='modal-body'>
               <div class='container-fluid'>
                 <div class='row'>
-                 <img id='overlayImage' src='assets/img/static-photo-video.png' style='width:100%;' title='Click to play the video.' onClick='videoModalController.playVideo()' />
-                  <!-- video code example, the high-voted answer, not the -1 answer on top: 
+                  <div class='btn-group-vertical pull-right' id='close-modal-button'>
+                    <button type='button' class='btn btn-xs btn-close' onclick='videoModalController.hideModal()'>
+                      <a href='#'>close</a>
+                    </button>
+                  </div>
+                  <img id='overlayImage' src='assets/img/static-photo-video.png' style='width:100%;' title='Click to play the video.' onClick='videoModalController.playVideo()' />
+                  <!-- video code example, the high-voted answer, not the -1 answer on top:
                        http://stackoverflow.com/questions/14616453/image-placeholder-fallback-for-html5-video -->
                   <video controls style='width:100%; display:none'>
                     <source src='assets/vid/SampleVideo_1280x720_1mb.mp4' type='video/mp4; codecs='avc1.42E01E, mp4a.40.2'' />
@@ -49,7 +54,7 @@
                     <img src='assets/img/static-photo-video.png' style='width:100%' title='Your browser does not support the <video> tag'>
                   </video>
                 </div>
-                
+
                 <div class='middle-gray-bar row'>
                   <div class='middle-title col-sm-2'>
                     Join Women <br /> for Hillary
@@ -78,7 +83,7 @@
                     <button type='button' class='btn btn-danger full-width-button'>Button</button>
                   </div>
                 </div>
-                
+
                 <div class='bottom-gray-bar row'>
                   <div class='col-sm-6 padded-half'>
                     <div class='bottom-title'>


### PR DESCRIPTION
What?  Solves issue https://github.com/DevProgress/maps-showcase/issues/50

Testing:
Use chrome dev console to look at it on mobile and in xs screens

Risks:
Low.  Just a button that calls a javascript function to close a mobile that already exists.  Could it break on another browser?  Probably not, I am not aware of other browsers not supporting buttons, but I am not a front end expert.

Gifs?
oh yah

desktop:
![desktop chrome](https://cloud.githubusercontent.com/assets/1569764/17833940/8dee8faa-66e1-11e6-8f68-31435ba3e470.gif)

mobile:
![mobile testing](https://cloud.githubusercontent.com/assets/1569764/17833938/8842b5ea-66e1-11e6-8b07-dc73db5276d5.gif)
