### PR TITLE
close modal window

### DIFF
--- a/site/assets/css/base.css
+++ b/site/assets/css/base.css
@@ -2,7 +2,7 @@
 
 #overlayImage {
   cursor: pointer;
-  width: 100%; 
+  width: 100%;
 }
 
 /* the play icon over the main popover image  */
@@ -71,6 +71,17 @@
   }
 }
 
+@media screen and (min-width: 0px) and (max-width: 768px) {
+  #close-modal-button { display: block; }  /* show it on small screens */
+}
+
+@media screen and (min-width: 768px){
+  #close-modal-button { display: none; }   /* hide it elsewhere */
+}
+
+.btn-close {
+  background-color: #eee;
+}
 
 /* Styles for bottom strip of page */
 .bottom-gray-bar {

--- a/site/index.html
+++ b/site/index.html
@@ -40,11 +40,16 @@
           <div class='modal-body'>
               <div class='container-fluid'>
                 <div class='row'>
-                   <div>
-                     <img id='overlayImage' src='assets/img/static-photo-video.png' title='Click to play the video.' onClick='videoModalController.playVideo()' />
-                     <span class='glyphicon glyphicon-play-circle centered-icon' onClick='videoModalController.playVideo()'></span>
-                   </div>
-                  <!-- video code example, the high-voted answer, not the -1 answer on top: 
+                  <div class='btn-group-vertical pull-right' id='close-modal-button'>
+                    <button type='button' class='btn btn-xs btn-close' onclick='videoModalController.hideModal()'>
+                      <a href='#'>close</a>
+                    </button>
+                  </div>
+                  <div>
+                    <img id='overlayImage' src='assets/img/static-photo-video.png' title='Click to play the video.' onClick='videoModalController.playVideo()' />
+                    <span class='glyphicon glyphicon-play-circle centered-icon' onClick='videoModalController.playVideo()'></span>
+                  </div>
+                  <!-- video code example, the high-voted answer, not the -1 answer on top:
                        http://stackoverflow.com/questions/14616453/image-placeholder-fallback-for-html5-video -->
                   <video controls style='width:100%; display:none'>
                     <source src='assets/vid/SampleVideo_1280x720_1mb.mp4' type='video/mp4; codecs='avc1.42E01E, mp4a.40.2'' />
@@ -52,7 +57,7 @@
                     <img src='assets/img/static-photo-video.png' style='width:100%' title='Your browser does not support the <video> tag'>
                   </video>
                 </div>
-                
+
                 <div class='middle-gray-bar row'>
                   <div class='middle-title col-sm-2'>
                     Join Women <br /> for Hillary
@@ -81,7 +86,7 @@
                     <button type='button' class='btn btn-danger full-width-button'>Button</button>
                   </div>
                 </div>
-                
+
                 <div class='bottom-gray-bar row'>
                   <div class='col-sm-6 padded-half'>
                     <div class='bottom-title'>


### PR DESCRIPTION
#### What?

Solves issue https://github.com/DevProgress/maps-showcase/issues/50
#### Testing:

Use chrome dev console to look at it on mobile and in xs screens
#### Risks:

Low.  Just a button that calls a javascript function to close a mobile that already exists.  Could it break on another browser?  Probably not, I am not aware of other browsers not supporting buttons, but I am not a front end expert.
##### Why does it say you are adding in  width: 100%; to overlayImage in the css file?

IDK, it already exists here on master https://github.com/DevProgress/maps-showcase/blob/master/site/assets/css/base.css#L5

Gifs?
oh yah

desktop:
![desktop chrome](https://cloud.githubusercontent.com/assets/1569764/17833940/8dee8faa-66e1-11e6-8f68-31435ba3e470.gif)

mobile:
![mobile testing](https://cloud.githubusercontent.com/assets/1569764/17833938/8842b5ea-66e1-11e6-8b07-dc73db5276d5.gif)
