### PR TITLE
Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ This is how we combine the data we ripped from the PDF and other data for the de
 # Style guide
 
 2 space indentation in js / html / css
+
+# Icons for navigation
+These are from https://github.com/google/material-design-icons
+Used under the CC attribution 4.0 liscense https://creativecommons.org/licenses/by/4.0/

--- a/site/assets/css/map.css
+++ b/site/assets/css/map.css
@@ -125,7 +125,14 @@ path:hover {
 #state-title {
   font-size: 24px;
   font-weight: 700;
+}
 
+
+@media (max-width: 500px) { /* equivalent to bootstrap min size, without using Less */
+  #state-title {
+    font-size: 18px;
+    font-weight: 700;
+  }
 }
 
 
@@ -133,40 +140,34 @@ path:hover {
 #modal-controls {
   position: absolute;
   right: 10px;
-  top: 22px;
+  top: 10px;
 
 }
-
 
 /* surround the arrows and X in the modal controls with a circle */
 .circle-background {
   background-color: white;
   border: 2px gray solid;
   border-radius: 50%;
-  display: inline;
-  padding: 16px;
-  padding-left: 18px;
-  padding-right: 14px;
-  margin-left: 16px;
+  display: inline-block;
+  padding: 10px;
+  margin-left: 10px;
+}
+
+@media (max-width: 768px) { /* equivalent to bootstrap min size, without using Less */
+  .circle-background {
+    padding: 5px;
+    margin-left: 3px;
+  }
 }
 
 
-.circle-background span {
-  color: gray;
-  font-size: 14px;
+.gray-svg {
+    fill: gray;
 }
-
 
 #modal-controls a:hover {
   text-decoration: none;
   cursor: pointer;
 }
 
-
-/* the X needs less left padding than the arrows to center, and more top padding */
-#close-button .circle-background {
-  padding-left: 15px;
-  padding-right: 17px;
-  padding-top: 16px;
-  padding-bottom: 14px;
-}

--- a/site/assets/img/ic_chevron_left_black_24px.svg
+++ b/site/assets/img/ic_chevron_left_black_24px.svg
@@ -1,0 +1,4 @@
+<svg fill="gray" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/site/assets/img/ic_chevron_right_black_24px.svg
+++ b/site/assets/img/ic_chevron_right_black_24px.svg
@@ -1,0 +1,4 @@
+<svg fill="gray" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/site/assets/img/ic_close_black_24px.svg
+++ b/site/assets/img/ic_close_black_24px.svg
@@ -1,0 +1,4 @@
+<svg fill="gray" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -126,17 +126,17 @@
             <div id='modal-controls'>
               <a id='left-arrow' onClick='modalController.previousState()'>
                 <div class='circle-background'>
-                  <span class='glyphicon glyphicon-arrow-left'></span>
+                  <img class='gray-svg' src="/assets/img/ic_chevron_left_black_24px.svg" />
                 </div>
               </a>
               <a id='right-arrow' onClick='modalController.nextState()'>
                 <div class='circle-background'>
-                  <span class='glyphicon glyphicon-arrow-right'></span>
+                  <img class='gray-svg' src="/assets/img/ic_chevron_right_black_24px.svg" />
                 </div>
               </a>
               <a id='close-button' onClick='modalController.hideModal()'>
                 <div class='circle-background'>
-                  <span class='glyphicon glyphicon-remove'></span>
+                  <img class='gray-svg' src="/assets/img/ic_close_black_24px.svg" />
                 </div>
               </a>
             </div>
@@ -259,7 +259,7 @@
               transform = "";
           }
 
-          //pan    
+          //pan
           if (scale != 1) {
               posX = last_posX + ev.deltaX;
               posY = last_posY + ev.deltaY;
@@ -308,7 +308,7 @@
     $( document ).ready(function() {
       var mapDiv = document.getElementById('map-container-outer');
       hammerIt(mapDiv)
-      
+
     });
     </script>
 });


### PR DESCRIPTION
What?

Nav buttons are large and overwrite the state text on mobile.  Also they are centered with really specific css rules and are not perfectly centered if you look closely.
https://github.com/DevProgress/maps-showcase/issues/52

Scaling the current code down for mobile was difficult because the centering was off and became even more pronounced on smaller screens.  

This replaces the glyphs with SVGs and centers them in the divs at all resolutions.

Testing: 
Tried at a variety of resolutions
SVG supported in 97% of web traffic
http://caniuse.com/#feat=svg

Risk:
Low, its just icons, but if something broke it would break navigation.

Gif:

![make me a gif](https://cloud.githubusercontent.com/assets/1569764/17880695/fde6de2a-68b2-11e6-9e15-6abc6cf36328.gif)
