### PR TITLE
fix modal scrolling on iOS Safari

### DIFF
--- a/site/css/site.css
+++ b/site/css/site.css
@@ -54,6 +54,8 @@ html, body {
 
 .modal-dialog {
   max-width: 600px;
+  -webkit-overflow-scrolling: auto !important;
+  overflow-y: auto !important;
 }
 
 .modal-dialog {


### PR DESCRIPTION
Fix for https://github.com/DevProgress/maps-showcase/issues/92

There's a bug in Safari; super long discussion and fix from https://github.com/twbs/bootstrap/issues/14839

I can reproduce the bug and fix with the Xcode simulator, but haven't (yet) tried it on a real iPhone.
